### PR TITLE
Expose Typer CLI and define project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,16 @@ version = "0.1.0"
 description = "Fantasy football auction value model"
 authors = [{name="FFA Contributors"}]
 requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2",
+    "typer",
+    "polars",
+    "pyyaml",
+    "pytest",
+]
+
+[project.scripts]
+ffa = "ffa.cli.main:app"
 
 [tool.black]
 line-length = 88
@@ -18,3 +28,6 @@ select = ["E","F","I","B"]
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["S101"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/ffa/cli/main.py
+++ b/src/ffa/cli/main.py
@@ -1,0 +1,7 @@
+import typer
+
+app = typer.Typer()
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- declare runtime dependencies and CLI script in `pyproject.toml`
- add minimal Typer app entrypoint for CLI
- configure pytest discovery for `tests`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66bc30bc8832280031f9082c8607c