### PR TITLE
Add league configuration model and loader

### DIFF
--- a/src/ffa/config/__init__.py
+++ b/src/ffa/config/__init__.py
@@ -1,1 +1,6 @@
-"""Subpackage for config functionality."""
+"""Configuration utilities for the FFA package."""
+
+from .league import LeagueConfig
+from .loader import league_config_schema, load_league_config
+
+__all__ = ["LeagueConfig", "load_league_config", "league_config_schema"]

--- a/src/ffa/config/league.py
+++ b/src/ffa/config/league.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Pydantic model for league configuration."""
+
+from typing import Dict
+
+from pydantic import BaseModel, Field
+
+
+class LeagueConfig(BaseModel):
+    """Configuration model for a fantasy football league.
+
+    Attributes
+    ----------
+    teams: int
+        Number of teams participating in the league.
+    budget: int
+        Budget available to each team for drafting players.
+    roster_slots: Dict[str, int]
+        Mapping of roster positions to the number of slots for each.
+    scoring_coefficients: Dict[str, float]
+        Coefficients applied to various statistics for scoring.
+    bonuses: Dict[str, float]
+        Optional bonuses awarded for achieving certain milestones.
+    thresholds: Dict[str, float]
+        Thresholds used for categorizing player performance.
+    """
+
+    teams: int
+    budget: int
+    roster_slots: Dict[str, int]
+    scoring_coefficients: Dict[str, float]
+    bonuses: Dict[str, float] = Field(default_factory=dict)
+    thresholds: Dict[str, float] = Field(default_factory=dict)

--- a/src/ffa/config/loader.py
+++ b/src/ffa/config/loader.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Utilities for loading league configuration files."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .league import LeagueConfig
+
+
+def load_league_config(path: str | Path) -> LeagueConfig:
+    """Load a league configuration from a YAML file.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML configuration file.
+
+    Returns
+    -------
+    LeagueConfig
+        The validated league configuration.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the provided path does not exist.
+    ValidationError
+        If the YAML contents do not conform to :class:`LeagueConfig`.
+    """
+
+    path = Path(path)
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return LeagueConfig.model_validate(data)
+
+
+def league_config_schema() -> dict[str, Any]:
+    """Return the JSON schema for :class:`LeagueConfig`."""
+
+    return LeagueConfig.model_json_schema()

--- a/src/ffa/config/template/league.yaml
+++ b/src/ffa/config/template/league.yaml
@@ -1,0 +1,21 @@
+# Template configuration for a fantasy football league
+teams: 12
+budget: 200
+roster_slots:
+  QB: 1
+  RB: 2
+  WR: 2
+  TE: 1
+  FLEX: 1
+  BENCH: 7
+scoring_coefficients:
+  pass_yds: 0.04
+  pass_tds: 4
+  rush_yds: 0.1
+  rush_tds: 6
+bonuses:
+  100_rush_yds: 3
+  100_rec_yds: 3
+thresholds:
+  bust: 5
+  star: 20

--- a/tests/config/test_league_config.py
+++ b/tests/config/test_league_config.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from ffa.config import LeagueConfig, league_config_schema, load_league_config
+
+
+def test_load_league_config_valid():
+    config_path = Path(__file__).resolve().parents[2] / "src/ffa/config/template/league.yaml"
+    config = load_league_config(config_path)
+    assert isinstance(config, LeagueConfig)
+    assert config.teams == 12
+    assert config.roster_slots["QB"] == 1
+
+
+def test_load_league_config_invalid(tmp_path):
+    bad_file = tmp_path / "bad.yaml"
+    bad_file.write_text("teams: 12\n")  # missing required fields
+    with pytest.raises(ValidationError):
+        load_league_config(bad_file)
+
+
+def test_league_config_schema():
+    schema = league_config_schema()
+    assert schema["title"] == "LeagueConfig"
+    for field in ["teams", "budget", "roster_slots", "scoring_coefficients"]:
+        assert field in schema["properties"]


### PR DESCRIPTION
## Summary
- define `LeagueConfig` pydantic model capturing league settings
- add YAML template and loader utilities with schema exposure
- verify configuration loading, validation, and schema generation

## Testing
- `pip install pydantic pyyaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a66bbc2ed483229fd753be94b4d2ff