### PR TITLE
Add CI workflow and status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - run: pip install ruff
+      - run: ruff check .
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - run: pip install black
+      - run: black --check .
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - run: pip install .
+      - run: pip install pytest
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fantasy Football Auction Value Model
 
+[![CI](https://github.com/OWNER/ff-redux/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/ff-redux/actions/workflows/ci.yml)
+
 This project provides a flexible framework for generating auction dollar values
 for fantasy football leagues. It supports custom league configurations,
 multiple data sources, and analytical techniques such as projections,

--- a/src/ffa/__init__.py
+++ b/src/ffa/__init__.py
@@ -1,31 +1,31 @@
 """Fantasy Football Auction (FFA) core package."""
 
 from . import (
+    adjust,
+    api,
+    calibrate,
+    cli,
     config,
     ids,
     ingest,
-    scoring,
-    adjust,
-    value,
-    calibrate,
     reports,
+    scoring,
     sim,
-    cli,
-    api,
     utils,
+    value,
 )
 
 __all__ = [
+    "adjust",
+    "api",
+    "calibrate",
+    "cli",
     "config",
     "ids",
     "ingest",
-    "scoring",
-    "adjust",
-    "value",
-    "calibrate",
     "reports",
+    "scoring",
     "sim",
-    "cli",
-    "api",
     "utils",
+    "value",
 ]

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running ruff, black, and pytest on Python 3.10-3.12
- document workflow with a README status badge
- sort imports to satisfy lint rules

## Testing
- `ruff check .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66bc149d08322a9b3cf870ad76335