### PR TITLE
Add Typer CLI entry point with smoke tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ version = "0.1.0"
 description = "Fantasy football auction value model"
 authors = [{name="FFA Contributors"}]
 requires-python = ">=3.10"
+dependencies = ["typer"]
+
+[project.scripts]
+ffa = "ffa.cli.main:app"
 
 [tool.black]
 line-length = 88

--- a/src/ffa/cli/main.py
+++ b/src/ffa/cli/main.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import typer
+
+from ffa.ingest import init as ingest_init
+from ffa.scoring import score as scoring_score
+from ffa.value import value as value_cmd
+from ffa.reports import report as report_cmd
+from ffa.sim import backtest as backtest_cmd
+
+app = typer.Typer(help="Fantasy Football Auction CLI")
+
+
+@app.command()
+def init(
+    config: Path = typer.Option(None, "--config", "-c", help="Path to configuration file"),
+) -> None:
+    """Initialize project resources."""
+    ingest_init(config)
+
+
+@app.command()
+def score(
+    config: Path = typer.Option(None, "--config", "-c", help="Path to configuration file"),
+) -> None:
+    """Run scoring logic."""
+    scoring_score(config)
+
+
+@app.command()
+def value(
+    config: Path = typer.Option(None, "--config", "-c", help="Path to configuration file"),
+) -> None:
+    """Calculate player values."""
+    value_cmd(config)
+
+
+@app.command()
+def report(
+    config: Path = typer.Option(None, "--config", "-c", help="Path to configuration file"),
+) -> None:
+    """Generate reports."""
+    report_cmd(config)
+
+
+@app.command()
+def backtest(
+    config: Path = typer.Option(None, "--config", "-c", help="Path to configuration file"),
+) -> None:
+    """Run backtest simulations."""
+    backtest_cmd(config)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/ffa/ingest/__init__.py
+++ b/src/ffa/ingest/__init__.py
@@ -1,1 +1,7 @@
 """Subpackage for ingest functionality."""
+
+from pathlib import Path
+
+def init(config_path: Path | None = None) -> None:
+    """Placeholder for initialization logic."""
+    _ = config_path

--- a/src/ffa/reports/__init__.py
+++ b/src/ffa/reports/__init__.py
@@ -1,1 +1,7 @@
 """Subpackage for reports functionality."""
+
+from pathlib import Path
+
+def report(config_path: Path | None = None) -> None:
+    """Placeholder for report generation logic."""
+    _ = config_path

--- a/src/ffa/scoring/__init__.py
+++ b/src/ffa/scoring/__init__.py
@@ -1,1 +1,7 @@
 """Subpackage for scoring functionality."""
+
+from pathlib import Path
+
+def score(config_path: Path | None = None) -> None:
+    """Placeholder for scoring logic."""
+    _ = config_path

--- a/src/ffa/sim/__init__.py
+++ b/src/ffa/sim/__init__.py
@@ -1,1 +1,7 @@
 """Subpackage for sim functionality."""
+
+from pathlib import Path
+
+def backtest(config_path: Path | None = None) -> None:
+    """Placeholder for backtesting logic."""
+    _ = config_path

--- a/src/ffa/value/__init__.py
+++ b/src/ffa/value/__init__.py
@@ -1,1 +1,7 @@
 """Subpackage for value functionality."""
+
+from pathlib import Path
+
+def value(config_path: Path | None = None) -> None:
+    """Placeholder for value calculation logic."""
+    _ = config_path

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def test_cli_help_shows_commands():
+    result = subprocess.run(["ffa", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0
+    stdout = result.stdout
+    for cmd in ["init", "score", "value", "report", "backtest"]:
+        assert cmd in stdout


### PR DESCRIPTION
## Summary
- implement Typer-powered CLI with commands for init, score, value, report and backtest
- wire commands to placeholder functions in subpackages
- expose CLI via `ffa` script in `pyproject.toml`
- add smoke test ensuring commands appear in `ffa --help`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66bbff284832282fd8af11251de01