### PR TITLE
Add basic FFA components with comprehensive tests

### DIFF
--- a/src/ffa/cli/__init__.py
+++ b/src/ffa/cli/__init__.py
@@ -1,1 +1,5 @@
-"""Subpackage for cli functionality."""
+"""FFA command line interface."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/src/ffa/cli/__main__.py
+++ b/src/ffa/cli/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/ffa/cli/main.py
+++ b/src/ffa/cli/main.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ..scoring import score_projections
+from ..value import calculate_values
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ffa")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init_p = sub.add_parser("init", help="initialise a project directory")
+    init_p.add_argument("path", type=Path)
+
+    score_p = sub.add_parser("score", help="produce scoring from projections")
+    score_p.add_argument("projections", type=Path)
+    score_p.add_argument("out", type=Path)
+
+    value_p = sub.add_parser("value", help="calculate values from scoring")
+    value_p.add_argument("scoring", type=Path)
+    value_p.add_argument("out", type=Path)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "init":
+        args.path.mkdir(parents=True, exist_ok=True)
+        config_path = args.path / "config.yaml"
+        default_cfg = {"data": "data", "output": "output"}
+        import yaml
+
+        with config_path.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(default_cfg, f)
+        (args.path / default_cfg["data"]).mkdir(exist_ok=True)
+        (args.path / default_cfg["output"]).mkdir(exist_ok=True)
+        return 0
+
+    if args.command == "score":
+        score_projections(args.projections, args.out)
+        return 0
+
+    if args.command == "value":
+        calculate_values(args.scoring, args.out)
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/ffa/config/__init__.py
+++ b/src/ffa/config/__init__.py
@@ -1,1 +1,5 @@
 """Subpackage for config functionality."""
+
+from .loader import load_config
+
+__all__ = ["load_config"]

--- a/src/ffa/config/loader.py
+++ b/src/ffa/config/loader.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - fallback when PyYAML missing
+    yaml = None
+
+
+def load_config(path: str | Path) -> dict:
+    """Load a configuration file in JSON or YAML format."""
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+
+    if file_path.suffix in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to load YAML config files")
+        with file_path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    else:
+        with file_path.open("r", encoding="utf-8") as f:
+            return json.load(f)

--- a/src/ffa/ids/__init__.py
+++ b/src/ffa/ids/__init__.py
@@ -1,1 +1,5 @@
 """Subpackage for ids functionality."""
+
+from .player import PlayerID
+
+__all__ = ["PlayerID"]

--- a/src/ffa/ids/player.py
+++ b/src/ffa/ids/player.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PlayerID:
+    """Simple identifier for a player."""
+
+    name: str
+    position: str
+    team: str
+
+    @classmethod
+    def from_row(cls, row: dict) -> "PlayerID":
+        """Create a :class:`PlayerID` from a mapping.
+
+        The mapping is expected to have at least the keys ``Name``,
+        ``_position`` (or ``Position``) and ``_team`` (or ``Team``).
+        """
+
+        name = row.get("Name") or row.get("Player")
+        position = row.get("_position") or row.get("Position")
+        team = row.get("_team") or row.get("Team")
+        return cls(name=name, position=position, team=team)
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return (self.name, self.position, self.team)

--- a/src/ffa/schemas/__init__.py
+++ b/src/ffa/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Schemas for FFA."""
+
+from .player import PlayerProjection
+
+__all__ = ["PlayerProjection"]

--- a/src/ffa/schemas/player.py
+++ b/src/ffa/schemas/player.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PlayerProjection:
+    """Light‑weight schema for a player's projection."""
+
+    name: str
+    position: str
+    team: str
+    points: float
+
+    def __post_init__(self) -> None:
+        if self.points < 0:
+            raise ValueError("points must be non-negative")

--- a/src/ffa/scoring/__init__.py
+++ b/src/ffa/scoring/__init__.py
@@ -1,1 +1,5 @@
-"""Subpackage for scoring functionality."""
+"""Scoring utilities."""
+
+from .core import score_projections
+
+__all__ = ["score_projections"]

--- a/src/ffa/scoring/core.py
+++ b/src/ffa/scoring/core.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from ..ids import PlayerID
+from ..schemas import PlayerProjection
+
+
+def score_projections(projections_file: str | Path, out_file: str | Path) -> None:
+    """Read a projections CSV and extract basic scoring info."""
+    projections_path = Path(projections_file)
+    out_path = Path(out_file)
+
+    players: list[PlayerProjection] = []
+    with projections_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            pid = PlayerID.from_row(row)
+            points = float(row["Points"])
+            players.append(
+                PlayerProjection(
+                    name=pid.name,
+                    position=pid.position,
+                    team=pid.team,
+                    points=points,
+                )
+            )
+
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["Name", "Position", "Team", "Points"])
+        writer.writeheader()
+        for p in players:
+            writer.writerow(
+                {
+                    "Name": p.name,
+                    "Position": p.position,
+                    "Team": p.team,
+                    "Points": p.points,
+                }
+            )

--- a/src/ffa/value/__init__.py
+++ b/src/ffa/value/__init__.py
@@ -1,1 +1,5 @@
-"""Subpackage for value functionality."""
+"""Value utilities."""
+
+from .core import calculate_values
+
+__all__ = ["calculate_values"]

--- a/src/ffa/value/core.py
+++ b/src/ffa/value/core.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+def calculate_values(scoring_file: str | Path, out_file: str | Path, multiplier: float = 1.2) -> None:
+    """Calculate simple valuations from a scoring file."""
+    scoring_path = Path(scoring_file)
+    out_path = Path(out_file)
+
+    with scoring_path.open(newline="", encoding="utf-8") as f_in, out_path.open(
+        "w", newline="", encoding="utf-8"
+    ) as f_out:
+        reader = csv.DictReader(f_in)
+        fieldnames = reader.fieldnames + ["Value"]
+        writer = csv.DictWriter(f_out, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in reader:
+            points = float(row["Points"])
+            row["Value"] = f"{points * multiplier:.2f}"
+            writer.writerow(row)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import subprocess
+import sys
+
+
+def run_cli(env: dict[str, str], *args: str) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, "-m", "ffa.cli", *args]
+    return subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+
+
+def test_init_creates_config(tmp_project: Path) -> None:
+    assert (tmp_project / "config.yaml").exists()
+    assert (tmp_project / "data").is_dir()
+    assert (tmp_project / "output").is_dir()
+
+
+def test_scoring_and_valuation_pipeline(tmp_project: Path, env: dict[str, str]) -> None:
+    data_file = Path("data/2024_weekly_proj/RB.csv")
+    scores_out = tmp_project / "scores.csv"
+    values_out = tmp_project / "values.csv"
+
+    run_cli(env, "score", str(data_file), str(scores_out))
+    assert scores_out.exists()
+
+    run_cli(env, "value", str(scores_out), str(values_out))
+    assert values_out.exists()
+
+    with values_out.open() as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+        assert "Value" in row and float(row["Value"]) > 0

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import yaml
+
+from ffa.config import load_config
+
+
+def test_load_yaml_config(tmp_path: Path) -> None:
+    cfg = {"answer": 42}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+
+    loaded = load_config(path)
+    assert loaded == cfg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure local ``src`` is on the import path for tests
+SRC = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture
+def env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC)
+    return env
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path, env: dict[str, str]) -> Path:
+    """Create a temporary FFA project directory using ``ffa init``."""
+    proj = tmp_path / "project"
+    subprocess.run([sys.executable, "-m", "ffa.cli", "init", str(proj)], check=True, env=env)
+    return proj

--- a/tests/ids/test_player.py
+++ b/tests/ids/test_player.py
@@ -1,0 +1,7 @@
+from ffa.ids import PlayerID
+
+
+def test_player_id_from_row() -> None:
+    row = {"Name": "Jane Doe", "_position": "RB", "_team": "FA"}
+    pid = PlayerID.from_row(row)
+    assert pid.as_tuple() == ("Jane Doe", "RB", "FA")

--- a/tests/schemas/test_player_schema.py
+++ b/tests/schemas/test_player_schema.py
@@ -1,0 +1,13 @@
+import pytest
+
+from ffa.schemas import PlayerProjection
+
+
+def test_player_projection_positive_points() -> None:
+    p = PlayerProjection("Jane", "RB", "FA", 10.5)
+    assert p.points == 10.5
+
+
+def test_player_projection_negative_points() -> None:
+    with pytest.raises(ValueError):
+        PlayerProjection("Jane", "RB", "FA", -1.0)


### PR DESCRIPTION
## Summary
- implement config loader for JSON/YAML files
- add PlayerID, projection schema, scoring and valuation utilities
- introduce CLI with init, score and value commands
- add end-to-end tests using sample data and CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66bc50c688322bb071d74ce410a55