### PR TITLE
Implement season aggregation in scoring engine

### DIFF
--- a/src/ffa/scoring/__init__.py
+++ b/src/ffa/scoring/__init__.py
@@ -1,8 +1,9 @@
 """Scoring utilities."""
 
 from .core import score_projections
+from .engine import aggregate_season
 
-__all__ = ["score_projections"]
+__all__ = ["score_projections", "aggregate_season"]
 
 
 from pathlib import Path

--- a/src/ffa/scoring/engine.py
+++ b/src/ffa/scoring/engine.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List
+
+from ..ingest.schemas import WeeklyStatRecord
+
+
+def aggregate_season(weekly_scores: Iterable[WeeklyStatRecord]) -> Dict[int, float]:
+    """Aggregate weekly fantasy scores into season totals per player.
+
+    Parameters
+    ----------
+    weekly_scores:
+        Iterable of :class:`WeeklyStatRecord` items.
+
+    Returns
+    -------
+    Dict[int, float]
+        Mapping of player ID to cumulative fantasy points for the season.
+
+    Notes
+    -----
+    A ``weekly_points`` attribute is attached to the function after
+    execution. It maps each player ID to a list of weekly point totals.
+    Missing weeks (e.g., bye weeks) are represented by ``0.0``.
+    """
+
+    totals: Dict[int, float] = defaultdict(float)
+    per_player_weeks: Dict[int, Dict[int, float]] = defaultdict(dict)
+    max_week = 0
+
+    for record in weekly_scores:
+        totals[record.player_id] += record.points
+        per_player_weeks[record.player_id][record.week] = record.points
+        if record.week > max_week:
+            max_week = record.week
+
+    weekly_points: Dict[int, List[float]] = {}
+    for pid, weeks in per_player_weeks.items():
+        weekly_points[pid] = [weeks.get(week, 0.0) for week in range(1, max_week + 1)]
+
+    # Attach detailed weekly breakdown for potential future use
+    aggregate_season.weekly_points = weekly_points  # type: ignore[attr-defined]
+
+    return dict(totals)

--- a/tests/scoring/test_engine.py
+++ b/tests/scoring/test_engine.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2] / "src"
+
+# ---------------------------------------------------------------------------
+# Set up minimal package structure to avoid executing full package __init__
+# ---------------------------------------------------------------------------
+ffa_pkg = types.ModuleType("ffa")
+ffa_pkg.__path__ = [str(ROOT / "ffa")]
+sys.modules.setdefault("ffa", ffa_pkg)
+scoring_pkg = types.ModuleType("ffa.scoring")
+scoring_pkg.__path__ = [str(ROOT / "ffa" / "scoring")]
+sys.modules.setdefault("ffa.scoring", scoring_pkg)
+ingest_pkg = types.ModuleType("ffa.ingest")
+ingest_pkg.__path__ = [str(ROOT / "ffa" / "ingest")]
+sys.modules.setdefault("ffa.ingest", ingest_pkg)
+
+# Load schemas and engine modules directly
+schemas_name = "ffa.ingest.schemas"
+spec_schemas = importlib.util.spec_from_file_location(
+    schemas_name, ROOT / "ffa" / "ingest" / "schemas.py"
+)
+schemas = importlib.util.module_from_spec(spec_schemas)
+sys.modules[schemas_name] = schemas
+assert spec_schemas.loader is not None
+spec_schemas.loader.exec_module(schemas)
+WeeklyStatRecord = schemas.WeeklyStatRecord
+
+spec_engine = importlib.util.spec_from_file_location(
+    "ffa.scoring.engine", ROOT / "ffa" / "scoring" / "engine.py"
+)
+engine = importlib.util.module_from_spec(spec_engine)
+sys.modules["ffa.scoring.engine"] = engine
+assert spec_engine.loader is not None
+spec_engine.loader.exec_module(engine)
+aggregate_season = engine.aggregate_season
+
+
+def test_aggregate_season_sums_and_bye_weeks():
+    weekly_scores = [
+        WeeklyStatRecord(player_id=1, season=2023, week=1, points=10.0),
+        WeeklyStatRecord(player_id=1, season=2023, week=2, points=12.0),
+        WeeklyStatRecord(player_id=1, season=2023, week=4, points=5.0),  # week 3 bye
+        WeeklyStatRecord(player_id=2, season=2023, week=1, points=8.0),
+        WeeklyStatRecord(player_id=2, season=2023, week=2, points=8.0),
+        WeeklyStatRecord(player_id=2, season=2023, week=3, points=8.0),
+    ]
+
+    totals = aggregate_season(weekly_scores)
+
+    assert totals[1] == pytest.approx(27.0)
+    assert totals[2] == pytest.approx(24.0)
+
+    for pid, total in totals.items():
+        assert total == pytest.approx(sum(aggregate_season.weekly_points[pid]))
+
+    assert aggregate_season.weekly_points[1] == [10.0, 12.0, 0.0, 5.0]
+    assert aggregate_season.weekly_points[2] == [8.0, 8.0, 8.0, 0.0]


### PR DESCRIPTION
## Summary
- add `aggregate_season` to compute season totals and retain per-week breakdown
- expose new function in scoring package
- test aggregation including bye weeks counted as zero

## Testing
- `pytest` *(fails: ImportError: cannot import name 'main' from 'ffa.cli.main')*
- `pytest tests/scoring/test_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6705e0ecc832283115d7740d956e2