### PR TITLE
Clean up config exports and update loader tests

### DIFF
--- a/src/ffa/cli/main.py
+++ b/src/ffa/cli/main.py
@@ -51,7 +51,12 @@ def backtest(
 ) -> None:
     """Run backtest simulations."""
     backtest_cmd(config)
-    
+
 
 if __name__ == "__main__":
+    app()
+
+
+def main() -> None:
+    """Entrypoint for the FFA CLI."""
     app()

--- a/src/ffa/config/__init__.py
+++ b/src/ffa/config/__init__.py
@@ -1,5 +1,3 @@
-__all__ = ["load_config"]
-
 """Configuration utilities for the FFA package."""
 
 from .league import LeagueConfig

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -2,13 +2,18 @@ from pathlib import Path
 
 import yaml
 
-from ffa.config import load_config
+from ffa.config import LeagueConfig, load_league_config
 
 
 def test_load_yaml_config(tmp_path: Path) -> None:
-    cfg = {"answer": 42}
+    cfg = {
+        "teams": 10,
+        "budget": 200,
+        "roster_slots": {"QB": 1},
+        "scoring_coefficients": {"pass_yds": 0.04},
+    }
     path = tmp_path / "config.yaml"
     path.write_text(yaml.safe_dump(cfg))
 
-    loaded = load_config(path)
-    assert loaded == cfg
+    loaded = load_league_config(path)
+    assert loaded == LeagueConfig(**cfg)


### PR DESCRIPTION
## Summary
- Remove redundant `__all__` declaration from `ffa.config` and expose schema loader and model only once
- Update loader test to call `load_league_config` and validate a minimal league configuration
- Add a `main` function to the CLI module for import stability

## Testing
- `pytest tests/config/test_loader.py tests/config/test_league_config.py -q`
- `pytest -q` *(fails: CLI tests expecting positional init argument and running `ffa` executable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6705bf35c8322accc7dd811da44da