### PR TITLE
Implement scoring engine with bonus thresholds

### DIFF
--- a/src/ffa/cli/main.py
+++ b/src/ffa/cli/main.py
@@ -55,3 +55,8 @@ def backtest(
 
 if __name__ == "__main__":
     app()
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    app()

--- a/src/ffa/config/__init__.py
+++ b/src/ffa/config/__init__.py
@@ -1,9 +1,11 @@
-__all__ = ["load_config"]
-
 """Configuration utilities for the FFA package."""
 
 from .league import LeagueConfig
-from .loader import league_config_schema, load_league_config
+from .loader import load_config, load_league_config, league_config_schema
 
-__all__ = ["LeagueConfig", "load_league_config", "league_config_schema"]
-
+__all__ = [
+    "LeagueConfig",
+    "load_config",
+    "load_league_config",
+    "league_config_schema",
+]

--- a/src/ffa/config/loader.py
+++ b/src/ffa/config/loader.py
@@ -37,6 +37,15 @@ def load_league_config(path: str | Path) -> LeagueConfig:
     return LeagueConfig.model_validate(data)
 
 
+def load_config(path: str | Path) -> dict[str, Any]:
+    """Load a generic YAML configuration file into a dictionary."""
+
+    path = Path(path)
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
 def league_config_schema() -> dict[str, Any]:
     """Return the JSON schema for :class:`LeagueConfig`."""
 

--- a/src/ffa/scoring/__init__.py
+++ b/src/ffa/scoring/__init__.py
@@ -1,11 +1,12 @@
 """Scoring utilities."""
 
-from .core import score_projections
-
-__all__ = ["score_projections"]
-
-
 from pathlib import Path
+
+from .core import score_projections
+from .engine import score_week
+
+__all__ = ["score_week", "score_projections"]
+
 
 def score(config_path: Path | None = None) -> None:
     """Placeholder for scoring logic."""

--- a/src/ffa/scoring/engine.py
+++ b/src/ffa/scoring/engine.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Core scoring engine.
+
+This module provides functionality to compute fantasy points for a single
+player's statistics in a given week according to league rules.
+"""
+
+from typing import Dict
+import re
+
+from ..config import LeagueConfig
+
+
+def score_week(stats_row: Dict[str, float], rules: LeagueConfig) -> float:
+    """Calculate fantasy points for a player's weekly statistics.
+
+    Parameters
+    ----------
+    stats_row: dict
+        Mapping of stat categories (e.g. ``pass_yds``, ``rush_tds``) to values.
+    rules: LeagueConfig
+        League configuration containing scoring coefficients and bonuses.
+
+    Returns
+    -------
+    float
+        Total fantasy points for the provided statistics.
+
+    Notes
+    -----
+    The function first applies linear scoring using coefficients defined in
+    ``rules.scoring_coefficients``. Bonus rules specified in ``rules.bonuses``
+    are then applied. Bonus keys are expected to use a ``"<threshold>_<stat>"``
+    format such as ``"100_rush_yds"`` or ``"40_long_rush_td"``. When the
+    corresponding stat in ``stats_row`` meets or exceeds ``threshold`` the
+    bonus is added to the final score.
+    """
+
+    score = 0.0
+
+    # Apply linear coefficients
+    for stat, coef in rules.scoring_coefficients.items():
+        value = float(stats_row.get(stat, 0))
+        score += value * coef
+
+    # Apply bonuses based on thresholds
+    threshold_pattern = re.compile(r"^(\d+)_([a-z_]+)$")
+    for bonus_key, bonus_value in rules.bonuses.items():
+        match = threshold_pattern.match(bonus_key)
+        if match:
+            threshold = float(match.group(1))
+            stat_key = match.group(2)
+            stat_value = float(stats_row.get(stat_key, 0))
+            if stat_value >= threshold:
+                score += bonus_value
+        else:
+            # Direct stat presence bonus
+            stat_value = float(stats_row.get(bonus_key, 0))
+            if stat_value:
+                score += bonus_value
+
+    return score

--- a/tests/scoring/test_engine.py
+++ b/tests/scoring/test_engine.py
@@ -1,0 +1,27 @@
+from ffa.config import LeagueConfig
+from ffa.scoring import score_week
+
+
+def test_score_week_linear() -> None:
+    rules = LeagueConfig(
+        teams=10,
+        budget=200,
+        roster_slots={"QB": 1},
+        scoring_coefficients={"pass_yds": 0.04, "rush_tds": 6, "turnovers": -2},
+    )
+    stats = {"pass_yds": 300, "rush_tds": 2, "turnovers": 1}
+    expected = 300 * 0.04 + 2 * 6 + 1 * -2
+    assert score_week(stats, rules) == expected
+
+
+def test_score_week_bonuses() -> None:
+    rules = LeagueConfig(
+        teams=12,
+        budget=200,
+        roster_slots={"RB": 2},
+        scoring_coefficients={"rush_yds": 0.1},
+        bonuses={"100_rush_yds": 3, "40_long_rush_td": 1},
+    )
+    stats = {"rush_yds": 120, "long_rush_td": 45}
+    expected = 120 * 0.1 + 3 + 1
+    assert score_week(stats, rules) == expected


### PR DESCRIPTION
## Summary
- add `score_week` engine to compute weekly fantasy points with bonus thresholds
- expose `score_week` via `ffa.scoring`
- add unit tests for linear and bonus scoring
- provide generic `load_config` helper and CLI entrypoint

## Testing
- `pytest tests/scoring/test_engine.py`
- `pytest tests/config/test_loader.py`
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffa' and subprocess errors in CLI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6705ceac4832281326ec960d25677